### PR TITLE
Channel endpoints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .DS_Store
 .vscode
+.idea
 target/
 Cargo.lock

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -1,41 +1,30 @@
 use anyhow::Error;
 use hyper::Method;
+use serde::{Deserialize, Deserializer, Serialize};
+use time::OffsetDateTime;
 
 use super::Context;
 use crate::{
     http::Request,
-    model::{channel::Channel, permission::Permissions, Id},
+    model::{
+        channel::*,
+        permission::Permissions,
+        Id, member::ThreadMember,
+        user::User},
 };
-
-impl Context {
+enum MessageQueryParams {
+    Around(Id),
+    Before(Id),
+    After(Id)
+}
+impl Channel {
     #[doc = discord_url!(
     "https://discord.com/developers/docs/resources/channel\
         #get-channel"
     )]
     #[doc = http_errors_doc!()]
-    pub async fn channel_by_id(
-        &self,
-        channel_id: Id,
-    ) -> Result<Channel, Error> {
-        self.empty_request(Request::new(
-            Permissions::ViewChannel.into(),
-            Method::GET,
-            format!("/channels/{channel_id}"),
-        ))
-            .await
-    }
-
-    #[doc = discord_url!(
-    "https://discord.com/developers/docs/resources/channel\
-        #modify-channel"
-    )]
-    #[doc = http_errors_doc!()]
-    pub async fn channel_modify(
-        &self,
-        channel_id: Id,
-    ) -> Result<Channel, Error> {
-        //             Permissions::ViewChannel.into(), Method::PATCH
-        unimplemented!()    // TODO: implement json params thingy (ew)
+    pub async fn from_id(ctx: &Context, id: &Id) -> Result<Channel,Error> {
+        ctx.channel_request_id(id, Method::GET)
     }
 
     #[doc = discord_url!(
@@ -43,16 +32,77 @@ impl Context {
         #deleteclose-channel"
     )]
     #[doc = http_errors_doc!()]
-    pub async fn channel_delete(
-        &self,
-        channel_id: Id,
+    pub async fn delete(ctx: &Context, id: &Id) -> Result<Channel,Error> {
+        ctx.channel_request_id(id, Method::DELETE)
+    }
+
+    pub async fn edit<F: FnOnce(ChannelModifier) -> ChannelModifier>(
+        self,
+        ctx: &Context,
+        f: F,
     ) -> Result<Channel, Error> {
-        self.empty_request(Request::new(
+        let id = self.id;
+        let patch = f(ChannelModifier::default());
+        let reply = ctx.request_with_params(Request::new(
             Permissions::ViewChannel.into(),
-            Method::DELETE,
-            format!("/channels/{channel_id}"),
-        ))
-            .await
+            Method::PATCH,
+            format!("/channels/{id}"),
+        ),
+                                patch
+        ).await?;
     }
 }
 
+impl Context {
+    pub async fn channel_request_id(
+        &self,
+        channel_id: &Id,
+        method: Method,
+    ) -> Result<Channel, Error> {
+        self.empty_request(Request::new(
+            Permissions::ViewChannel.into(),
+            method,
+            format!("/channels/{channel_id}"),
+        ))
+            .await?
+    }
+
+
+}
+
+/// The little worker people enter the computer and change the channel through here
+/// any data passed through here can be built into new or existing channel (build, patch)
+/// TODO: finish
+#[derive(Default, Debug, Copy, Serialize, Deserialize)]
+struct ChannelEdit {
+    pub id: Id,
+    pub channel_type: ChannelType,
+    pub guild_id: Option<Id>,
+    pub position: Option<u16>,
+    pub permission_overwrites: Option<Vec<PermissionOverwrite>>,
+    pub name: Option<String>,
+    pub topic: Option<String>,
+    pub nsfw: Option<bool>,
+    pub last_message_id: Option<Id>,
+    pub bitrate: Option<u32>,
+    pub user_limit: Option<u8>,
+    pub rate_limit_per_user: Option<u16>,
+    pub recipients: Option<Vec<User>>,
+    pub icon: Option<String>,
+    pub owner_id: Option<Id>,
+    pub application_id: Option<Id>,
+    pub parent_id: Option<Id>,
+    pub last_pin_timestamp: Option<OffsetDateTime>,
+    pub rtc_region: Option<String>,
+    pub video_quality_mode: Option<VideoQualityMode>,
+    pub message_count: Option<u32>,
+    pub member_count: Option<u8>,
+    pub thread_metadata: Option<Thread>,
+    pub member: Option<ThreadMember>,
+    pub default_auto_archive_duration: Option<u16>,
+    pub permissions: Option<Permissions>,
+    pub flags: Option<ChannelFlags>,
+    pub total_message_sent: Option<u32>,
+    #[doc = discord_url!("https://discord.com/developers/docs/topics/gateway#thread-create")]
+    pub newly_created: Option<bool>,
+}

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -1,0 +1,58 @@
+use anyhow::Error;
+use hyper::Method;
+
+use super::Context;
+use crate::{
+    http::Request,
+    model::{channel::Channel, permission::Permissions, Id},
+};
+
+impl Context {
+    #[doc = discord_url!(
+    "https://discord.com/developers/docs/resources/channel\
+        #get-channel"
+    )]
+    #[doc = http_errors_doc!()]
+    pub async fn channel_by_id(
+        &self,
+        channel_id: Id,
+    ) -> Result<Channel, Error> {
+        self.empty_request(Request::new(
+            Permissions::ViewChannel.into(),
+            Method::GET,
+            format!("/channels/{channel_id}"),
+        ))
+            .await
+    }
+
+    #[doc = discord_url!(
+    "https://discord.com/developers/docs/resources/channel\
+        #modify-channel"
+    )]
+    #[doc = http_errors_doc!()]
+    pub async fn channel_modify(
+        &self,
+        channel_id: Id,
+    ) -> Result<Channel, Error> {
+        //             Permissions::ViewChannel.into(), Method::PATCH
+        unimplemented!()    // TODO: implement json params thingy (ew)
+    }
+
+    #[doc = discord_url!(
+    "https://discord.com/developers/docs/resources/channel\
+        #deleteclose-channel"
+    )]
+    #[doc = http_errors_doc!()]
+    pub async fn channel_delete(
+        &self,
+        channel_id: Id,
+    ) -> Result<Channel, Error> {
+        self.empty_request(Request::new(
+            Permissions::ViewChannel.into(),
+            Method::DELETE,
+            format!("/channels/{channel_id}"),
+        ))
+            .await
+    }
+}
+

--- a/src/guild.rs
+++ b/src/guild.rs
@@ -1,0 +1,18 @@
+use anyhow::Error;
+use hyper::Method;
+use serde::{Deserialize, Deserializer};
+use time::OffsetDateTime;
+
+use super::Context;
+use crate::{
+    http::Request,
+    model::{
+        channel::*,
+        permission::Permissions,
+        Id, member::ThreadMember,
+        user::User},
+};
+
+impl Context {
+
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -108,6 +108,8 @@ macro_rules! http_errors_doc {
 
 /// Context method on auto moderation
 mod auto_moderation;
+/// Context method for channels
+mod channel;
 /// Implementation of the HTTP client to make requests to Discord
 pub mod http;
 /// Discord objects and (de)serialization implementations on them

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -117,6 +117,8 @@ pub mod model;
 /// Tests for everything in Daybreak
 #[cfg(test)]
 mod tests;
+/// Message impl
+mod message;
 
 #[derive(Debug)]
 #[allow(clippy::multiple_inherent_impl)]

--- a/src/message.rs
+++ b/src/message.rs
@@ -1,0 +1,120 @@
+use enumflags2::bitflags;
+use serde::{Deserialize, Serialize};
+use serde_repr::{Deserialize_repr, Serialize_repr};
+use time::OffsetDateTime;
+
+use super::Context;
+use crate::{
+    http::Request,
+    model::{
+        embed::Embed,
+        message:*
+        permission::Permissions,
+        Id, member::ThreadMember,
+        user::User,
+        message::*
+    },
+};
+
+#[doc = discord_url!(
+"https://discord.com/developers/docs/resources/channel#create-message"
+)]
+/// TODO: 'FILES MUST BE ATTACHED USING A MULTIPART/FORM-DATA BODY AS DESXCRIBED IN UPLOADING FILES'
+///  At least one of content, embeds, sticker_ids, components, or files[n] is required.
+pub struct MessageSay {
+    content: Option<String>,
+    nonce:  Option<String>, // tee hee funny nonce
+    tts: Option<bool>,
+    embeds: Vec<Embed>,
+    allowed_mentions: Option<AllowedMentions>,
+    message_reference: Option<MessageReference>,
+    components: Vec<Message>,
+    sticker_ids: Vec<Id>,
+    // This stuff should be handled via Attachment
+    //files: Vec<String>, // TODO: FILES
+    //payload_json: Option<String>, // uploading files stuff
+    attachments: Vec<Attachment>,
+    flags: Option<u8>,
+}
+
+impl MessageSay {
+    pub fn validate(&self) -> bool {
+        // eek
+        self.content.is_some()
+            || !self.embeds.is_empty()
+            || !self.sticker_ids.is_empty()
+            || !self.components.is_empty()
+    }
+    pub fn content(self, text: &str) -> Self {
+        Self {
+            content: Some(text.to_string()),
+            ..self
+        }
+    }
+    pub fn nonce(self, nonce: &str) -> Self {
+        Self {
+            nonce: Some(nonce.to_string()),
+            ..self
+        }
+    }
+    pub fn tts(self, tts: bool) -> Self {
+        Self {
+            tts: Some(tts),
+            ..self
+        }
+    }
+    pub fn embeds(self, embeds: Vec<Embed>) -> Self {
+        Self {
+            embeds,
+            ..self
+        }
+    }
+    pub fn allowed_mentions(self, mentions: AllowedMentions) -> Self {
+        Self {
+            allowed_mentions: Some(mentions),
+            ..self
+        }
+    }
+    pub fn message_ref(self, reference: MessageReference) -> Self {
+        Self {
+            message_reference: Some(reference),
+            ..self
+        }
+    }
+    pub fn components(self, components: Vec<Message>) -> Self {
+        Self {
+            components,
+            ..self
+        }
+    }
+    pub fn stickers(self, sticker_ids: Vec<Id>) -> Self {
+        Self {
+            sticker_ids,
+            ..self
+        }
+    }
+
+
+}
+
+#[doc = discord_url!(
+"https://discord.com/developers/docs/resources/channel#create-message"
+)]
+/// TODO: 'FILES MUST BE ATTACHED USING A MULTIPART/FORM-DATA BODY AS DESXCRIBED IN UPLOADING FILES'
+///  At least one of content, embeds, sticker_ids, components, or files[n] is required.
+pub struct AttachmentSay {
+    attachments: Vec<Attachment>,
+    message: Option<MessageSay>
+}
+
+impl AttachmentSay {
+    pub fn validate(&self) -> bool {
+        // eek
+        !self.attachments.is_empty()
+    }
+    pub fn attach(self) -> Self {
+        todo!()
+    }
+
+
+}

--- a/src/model.rs
+++ b/src/model.rs
@@ -55,39 +55,50 @@ use anyhow::Error;
 use serde::{Deserialize, Serialize};
 use time::{Duration, OffsetDateTime};
 
-#[doc = discord_url!("https://discord.com/developers/docs/reference#snowflakes")]
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
-#[serde(try_from = "String")]
-pub struct Id(pub u64);
 
-impl Display for Id {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.0)
+// TODO: specialized ID
+
+#[macro_export]
+macro_rules! id {
+    ( $variant:ident ) => {
+            #[doc = discord_url!("https://discord.com/developers/docs/reference#snowflakes")]
+            #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+            #[serde(try_from = "String")]
+            pub struct $variant(pub u64);
+
+            impl Display for $variant {
+                fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                    write!(f, "{}", self.0)
+                }
+            }
+
+            impl TryFrom<String> for $variant {
+                type Error = ParseIntError;
+                fn try_from(s: String) -> Result<Self, Self::Error> {
+                    Ok(Self(s.parse()?))
+                }
+            }
+
+            impl $variant {
+                /// The unix timestamp of the ID
+                #[doc = discord_url!(
+                    "https://discord.com/developers/docs/reference\
+                        #snowflakes-snowflake-id-format-structure-left-to-right"
+                )]
+                #[allow(
+                    clippy::integer_arithmetic,
+                    clippy::cast_possible_wrap,
+                    clippy::as_conversions
+                )]
+            pub fn timestamp(self) -> Result<OffsetDateTime, Error> {
+                    Ok(OffsetDateTime::from_unix_timestamp(
+                        Duration::milliseconds(((self.0 >> 22) + 1_420_070_400_000) as i64)
+                        .whole_seconds(),
+                    )?)
+                }
+            }
     }
 }
 
-impl TryFrom<String> for Id {
-    type Error = ParseIntError;
-
-    fn try_from(s: String) -> Result<Self, Self::Error> {
-        Ok(Self(s.parse()?))
-    }
-}
-
-impl Id {
-    /// The unix timestamp of the ID
-    #[doc = discord_url!(
-        "https://discord.com/developers/docs/reference\
-        #snowflakes-snowflake-id-format-structure-left-to-right"
-    )]
-    #[allow(
-        clippy::integer_arithmetic,
-        clippy::cast_possible_wrap,
-        clippy::as_conversions
-    )]
-    pub fn timestamp(self) -> Result<OffsetDateTime, Error> {
-        Ok(OffsetDateTime::from_unix_timestamp(
-            Duration::milliseconds(((self.0 >> 22) + 1_420_070_400_000) as i64).whole_seconds(),
-        )?)
-    }
-}
+id!(Id); // TODO: remove instances of Id and replace with suitable alternatives.
+id!(ChannelId);

--- a/src/model.rs
+++ b/src/model.rs
@@ -78,6 +78,13 @@ impl TryFrom<String> for Id {
     }
 }
 
+impl From<u64> for Id {
+    fn from(n: u64) -> Self {
+        Self(n)
+    }
+}
+
+
 impl Id {
     /// The unix timestamp of the ID
     #[doc = discord_url!(

--- a/src/model.rs
+++ b/src/model.rs
@@ -58,6 +58,47 @@ use time::{Duration, OffsetDateTime};
 
 // TODO: specialized ID
 
+// TODO: specialized ID
+
+#[doc = discord_url!("https://discord.com/developers/docs/reference#snowflakes")]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(try_from = "String")]
+pub struct Id(pub u64);
+
+impl Display for Id {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl TryFrom<String> for Id {
+    type Error = ParseIntError;
+    fn try_from(s: String) -> Result<Self, Self::Error> {
+        Ok(Self(s.parse()?))
+    }
+}
+
+impl Id {
+    /// The unix timestamp of the ID
+    #[doc = discord_url!(
+    "https://discord.com/developers/docs/reference\
+                        #snowflakes-snowflake-id-format-structure-left-to-right"
+    )]
+    #[allow(
+    clippy::integer_arithmetic,
+    clippy::cast_possible_wrap,
+    clippy::as_conversions
+    )]
+    pub fn timestamp(self) -> Result<OffsetDateTime, Error> {
+        Ok(OffsetDateTime::from_unix_timestamp(
+            Duration::milliseconds(((self.0 >> 22) + 1_420_070_400_000) as i64)
+                .whole_seconds(),
+        )?)
+    }
+}
+
+// ID macro
+/*
 #[macro_export]
 macro_rules! id {
     ( $variant:ident ) => {
@@ -102,3 +143,5 @@ macro_rules! id {
 
 id!(Id); // TODO: remove instances of Id and replace with suitable alternatives.
 id!(ChannelId);
+
+ */

--- a/src/model/channel.rs
+++ b/src/model/channel.rs
@@ -42,49 +42,6 @@ pub struct Channel {
     pub newly_created: Option<bool>,
 }
 
-/// The little worker people enter the computer and change the channel through here
-/// any data passed through here can be built into new or existing channel (build, patch)
-struct ChannelBuilder {
-    pub id: Id,
-    pub channel_type: ChannelType,
-    pub guild_id: Option<Id>,
-    pub position: Option<u16>,
-    pub permission_overwrites: Option<Vec<PermissionOverwrite>>,
-    pub name: Option<String>,
-    pub topic: Option<String>,
-    pub nsfw: Option<bool>,
-    pub last_message_id: Option<Id>,
-    pub bitrate: Option<u32>,
-    pub user_limit: Option<u8>,
-    pub rate_limit_per_user: Option<u16>,
-    pub recipients: Option<Vec<User>>,
-    pub icon: Option<String>,
-    pub owner_id: Option<Id>,
-    pub application_id: Option<Id>,
-    pub parent_id: Option<Id>,
-    pub last_pin_timestamp: Option<OffsetDateTime>,
-    pub rtc_region: Option<String>,
-    pub video_quality_mode: Option<VideoQualityMode>,
-    pub message_count: Option<u32>,
-    pub member_count: Option<u8>,
-    pub thread_metadata: Option<Thread>,
-    pub member: Option<ThreadMember>,
-    pub default_auto_archive_duration: Option<u16>,
-    pub permissions: Option<Permissions>,
-    pub flags: Option<ChannelFlags>,
-    pub total_message_sent: Option<u32>,
-    #[doc = discord_url!("https://discord.com/developers/docs/topics/gateway#thread-create")]
-    pub newly_created: Option<bool>,
-}
-
-impl ChannelBuilder {
-    pub async fn build(self) -> Channel {
-        todo!()
-    }
-    pub async fn patch(self, channel: Channel) -> Channel {
-        todo!()
-    }
-}
 
 #[doc = discord_url!(
     "https://discord.com/developers/docs/resources/channel#channel-object-channel-types"

--- a/src/model/channel.rs
+++ b/src/model/channel.rs
@@ -40,6 +40,50 @@ pub struct Channel {
     pub newly_created: Option<bool>,
 }
 
+/// The little worker people enter the computer and change the channel through here
+/// any data passed through here can be built into new or existing channel (build, patch)
+struct ChannelBuilder {
+    pub id: Id,
+    pub channel_type: ChannelType,
+    pub guild_id: Option<Id>,
+    pub position: Option<u16>,
+    pub permission_overwrites: Option<Vec<PermissionOverwrite>>,
+    pub name: Option<String>,
+    pub topic: Option<String>,
+    pub nsfw: Option<bool>,
+    pub last_message_id: Option<Id>,
+    pub bitrate: Option<u32>,
+    pub user_limit: Option<u8>,
+    pub rate_limit_per_user: Option<u16>,
+    pub recipients: Option<Vec<User>>,
+    pub icon: Option<String>,
+    pub owner_id: Option<Id>,
+    pub application_id: Option<Id>,
+    pub parent_id: Option<Id>,
+    pub last_pin_timestamp: Option<OffsetDateTime>,
+    pub rtc_region: Option<String>,
+    pub video_quality_mode: Option<VideoQualityMode>,
+    pub message_count: Option<u32>,
+    pub member_count: Option<u8>,
+    pub thread_metadata: Option<Thread>,
+    pub member: Option<ThreadMember>,
+    pub default_auto_archive_duration: Option<u16>,
+    pub permissions: Option<Permissions>,
+    pub flags: Option<ChannelFlags>,
+    pub total_message_sent: Option<u32>,
+    #[doc = discord_url!("https://discord.com/developers/docs/topics/gateway#thread-create")]
+    pub newly_created: Option<bool>,
+}
+
+impl ChannelBuilder {
+    pub async fn build(self) -> Channel {
+        todo!()
+    }
+    pub async fn patch(self, channel: Channel) -> Channel {
+        todo!()
+    }
+}
+
 #[doc = discord_url!(
     "https://discord.com/developers/docs/resources/channel#channel-object-channel-types"
 )]


### PR DESCRIPTION
Tbf

- Channel Modify
- Revert move back to context (meeeeh)
- revert ids(?) I still feel like being to call methods via the id type is still more friendly than via 'context', but if this is adamant it will also be changed